### PR TITLE
Guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
   },
   "require": {
     "php": ">=5.5",
-    "guzzlehttp/guzzle": "^6.3",
     "psr/log": "^1.0"
   },
   "autoload": {
@@ -27,6 +26,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^4.8",
+    "guzzlehttp/guzzle": "^7.3"
   }
 }


### PR DESCRIPTION
Moved guzzle dependency to require-dev. Also switched to 7.3 version.