### PR TITLE
Fix Deprecation notice with null value

### DIFF
--- a/src/Deskpro/API/DeskproClient.php
+++ b/src/Deskpro/API/DeskproClient.php
@@ -154,8 +154,9 @@ class DeskproClient implements DeskproClientInterface
      */
     public function setHelpdeskUrl($helpdeskUrl)
     {
-        $this->helpdeskUrl = rtrim($helpdeskUrl, '/');
-
+        if (!is_null($helpdeskUrl)) {
+            $this->helpdeskUrl = rtrim($helpdeskUrl, '/');
+        }
         return $this;
     }
 


### PR DESCRIPTION
With PHP 8.1.12, if I use this module without turn off deprecation notice, I'm getting:

Deprecated:
rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/vendor/deskpro/deskpro-api-client-php/src/Deskpro/API/DeskproClient.php on line 157

To fix it, simply check if parameter is not null,m before set property